### PR TITLE
Estimate the handle cost

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bako-id/sdk",
-  "version": "0.0.6",
+  "version": "0.0.6-dev",
   "description": "SDK to interact with domains in Bako.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,9 @@
 export { Domain, ResolverReturn } from './types';
-export { resolver, register, reverseResolver } from './methods';
+export {
+  resolver,
+  register,
+  reverseResolver,
+  simulateHandleCost,
+} from './methods';
 export { domainPrices, isValidDomain } from './utils';
 export { config } from './config';


### PR DESCRIPTION
Created a method to get a fee cost of a handle.

Example in use:
```ts
const { fee } = await simulateHandleCost({
      account: wallet,
      resolver: wallet.address.toB256(),
      domain: '@domain',
});

console.log(fee.format()); // 0.0000712...
```
