### PR TITLE
[FIX]: Connectors White Screen

### DIFF
--- a/apps/ui/src/components/helpers/connect.tsx
+++ b/apps/ui/src/components/helpers/connect.tsx
@@ -5,7 +5,7 @@ import { useScreenSize } from '../../hooks/useScreenSize';
 import { WalletIcon } from '../icons/wallet';
 
 export const Connect = () => {
-  const { connectors } = useFuelConnect();
+  const { connectors, isConnectError } = useFuelConnect();
   const { isMobile } = useScreenSize();
 
   return (
@@ -22,7 +22,7 @@ export const Connect = () => {
         _hover={{ bgColor: 'button.600' }}
         className="transition-all-05"
       >
-        {!connectors.isConnecting ? (
+        {!connectors.isConnecting && !isConnectError ? (
           <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
             {!isMobile && (
               <Icon

--- a/apps/ui/src/hooks/useFuelConnect.ts
+++ b/apps/ui/src/hooks/useFuelConnect.ts
@@ -1,7 +1,6 @@
 import { useDisclosure } from '@chakra-ui/react';
 import { useAccount, useFuel, useWallet } from '@fuels/react';
-import { useMemo, useState } from 'react';
-import { useCustomToast } from '../components/toast';
+import { useEffect, useMemo, useState } from 'react';
 import { IconUtils } from '../utils/users';
 import { EConnectors, useDefaultConnectors } from './fuel/useListConnectors';
 
@@ -13,8 +12,7 @@ export const useFuelConnect = () => {
   const connectorDrawer = useDisclosure();
   const { connectors } = useDefaultConnectors();
   const [isConnecting, setIsConnecting] = useState(false);
-
-  const { errorToast } = useCustomToast();
+  const [isConnectError, setIsConnectError] = useState(false);
 
   const selectConnector = async (connector: string) => {
     await fuel.selectConnector(connector);
@@ -35,10 +33,8 @@ export const useFuelConnect = () => {
 
       setIsConnecting(false);
     } catch (e) {
-      errorToast({
-        title: 'Error connecting to wallet',
-        description: e as string,
-      });
+      setIsConnectError(true);
+      return console.error('[Connect Error]', e);
     }
   };
 
@@ -58,11 +54,22 @@ export const useFuelConnect = () => {
     }
   }, [account]);
 
+  useEffect(() => {
+    if (isConnectError) {
+      setTimeout(() => {
+        setIsConnectError(false);
+        setIsConnecting(false);
+      }, 500);
+    }
+  }, [isConnectError]);
+
   return {
     wallet,
+    isConnectError,
     currentAccount: account,
     connectors: {
       isConnecting,
+      isConnectError,
       item: connectors,
       drawer: connectorDrawer,
       select: selectConnector,


### PR DESCRIPTION
**What was done:**

- Adjusted `catch` error for stopping white screen after users cancel connection with fuel wallet.
- Added a `useEffect` for keeping setting to false the `isConnectError` and `isConnecting` to improve better experience for user after cancel the connection and attempt to try again.
> Only for the button change to `Connecting...` and `Wallett Connect`