### PR TITLE
Avatar upload improviments

### DIFF
--- a/apps/ui/src/components/modal/editProfilePicModal.tsx
+++ b/apps/ui/src/components/modal/editProfilePicModal.tsx
@@ -25,10 +25,12 @@ const EditProfilePicBox = ({
   setUploadedFile,
   isSigning,
   nftImagePreview,
+  setInputValue,
 }: {
   setUploadedFile: React.Dispatch<React.SetStateAction<File | undefined>>;
   isSigning: boolean;
   nftImagePreview: string | null | undefined;
+  setInputValue: React.Dispatch<React.SetStateAction<string>>;
 }) => {
   const [isDragging, setIsDragging] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -66,6 +68,7 @@ const EditProfilePicBox = ({
   const handleDeleteUploadedFile = () => {
     setUploadedFile(undefined);
     setPreviewUrl(null);
+    setInputValue('');
 
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
@@ -120,10 +123,10 @@ const EditProfilePicBox = ({
       borderColor={isDragging ? 'grey.100' : 'grey.400'}
       p={4}
       bg={isDragging ? 'grey.600' : 'transparent'}
-      onDragEnter={handleDragEnter}
-      onDragLeave={handleDragLeave}
-      onDragOver={handleDragOver}
-      onDrop={handleDrop}
+      onDragEnter={!nftImagePreview ? handleDragEnter : undefined}
+      onDragLeave={!nftImagePreview ? handleDragLeave : undefined}
+      onDragOver={!nftImagePreview ? handleDragOver : undefined}
+      onDrop={!nftImagePreview ? handleDrop : undefined}
       transition="all 0.2s ease"
       pointerEvents={isSigning ? 'none' : 'unset'}
       position="relative"
@@ -154,7 +157,7 @@ const EditProfilePicBox = ({
         display="none"
       />
 
-      {nftImagePreview ? null : previewUrl ? (
+      {nftImagePreview || previewUrl ? (
         <Button
           position="absolute"
           bg="error.500"
@@ -302,6 +305,7 @@ export const EditProfilePicModal = ({
           setUploadedFile={setUploadedFile}
           isSigning={isSigning}
           nftImagePreview={nftImage ?? undefined}
+          setInputValue={setInputValue}
         />
         <Text color="grey.subtitle" mt={6} fontSize="xs">
           Or insert NFT Asset ID:
@@ -328,11 +332,17 @@ export const EditProfilePicModal = ({
           border="1px solid"
           borderColor="grey.500"
           borderRadius={10}
-          isDisabled={isSigning || isNftImageLoading}
+          isDisabled={isSigning || isNftImageLoading || !!uploadedFile}
           _focus={{}}
           _hover={{}}
           _focusVisible={{}}
         />
+
+        {!isNftImageLoading && isValidAssetId && !nftImage && (
+          <Text fontSize="xs" color="error.500" my={1}>
+            Invalid Asset ID. Ensure it is a Fuel-compatible NFT.
+          </Text>
+        )}
       </Dialog.Body>
       <Dialog.Actions hideDivider mt={56}>
         <Dialog.SecondaryAction onClick={handleClose} isDisabled={isSigning}>

--- a/apps/ui/src/components/user/userAvatar.tsx
+++ b/apps/ui/src/components/user/userAvatar.tsx
@@ -124,6 +124,8 @@ const EditProfilePicAvatar = ({
           <Box position="relative" w="full" h="full">
             <Image
               src={avatar}
+              referrerPolicy="no-referrer"
+              fetchPriority="high"
               alt="Profile avatar"
               w="full"
               h="full"
@@ -170,6 +172,8 @@ const ProfileAvatar = ({
       {avatar && !noAvatarFromUrl ? (
         <Image
           src={avatar}
+          referrerPolicy="no-referrer"
+          fetchPriority="high"
           alt="Profile avatar"
           w="full"
           h="full"


### PR DESCRIPTION
# Description
 Some UX improviments on avatar upload logic and avoid using cached avatar/images

# Summary
- [x] Added `fetchPriority` and `referrerPolicy` to `UserAvatar` component to avoid using cached images. This was necessary because sometimes, when users uploaded a new image from his computer, due the url still the same, the browser was using the same image/cached instead of fetching a new one. 
- [x] We already had a toast to tell the user when the nft assedId was wrong, but now we also added an label below the input.
- [x] Disabled the nft assetId input when users upload a image 

# Screenshots
![image](https://github.com/user-attachments/assets/c77a34e1-f145-43de-bb1e-1a14ed9b93b6)

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task