### PR TITLE
NFT CARD: Added a limit to nft text

### DIFF
--- a/apps/ui/src/modules/profile/components/profileCards.tsx
+++ b/apps/ui/src/modules/profile/components/profileCards.tsx
@@ -69,6 +69,7 @@ const NFTText = ({
     minW="fit-content"
     w="full"
     p={3}
+    mr={1}
     gap={3}
     alignItems="center"
     borderRadius="md"
@@ -101,7 +102,7 @@ const NFTText = ({
         {title}
       </Text>
       <Flex gap={2}>
-        <Text fontSize="xs">
+        <Text fontSize="xs" wordBreak="break-all">
           {isB256(value!) ? formatAddress(value!, 9) : value}
         </Text>
         {isCopy && <CopyText value={value!} />}
@@ -295,6 +296,7 @@ const NFTCard = (props: { asset: FuelAsset & { image?: string } }) => {
                 <Heading fontSize="md">Metadata</Heading>
                 <Flex
                   w="full"
+                  maxW={{ base: 'full', md: '425px' }}
                   maxH="310px"
                   overflowY="scroll"
                   direction="row"


### PR DESCRIPTION
# Description
We had a task to fix the nft card description before but now the problem was the nft text.

# Summary
- [x] Added a max width to nft text container

# Screenshots
![image](https://github.com/user-attachments/assets/b3e3fc3a-6d78-4bd4-83bb-12741879ee35)
![image](https://github.com/user-attachments/assets/9eea28d9-2f82-4a59-85ca-d406943ca556)


# Checklist
- [ ] I reviewed my PR code before submitting
- [ ] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [ ] I mentioned the PR link in the task