### PR TITLE
fix(conversion usd): remove comma from string before conversion to number

### DIFF
--- a/apps/ui/src/modules/marketplace/order/page.tsx
+++ b/apps/ui/src/modules/marketplace/order/page.tsx
@@ -65,7 +65,7 @@ export default function OrderPage() {
     [order?.itemPrice, order?.asset?.decimals]
   );
 
-  const usdValue = useMemo(() => Number(value) * rate, [value, rate]);
+  const usdValue = useMemo(() => Number(value.replace(/,/g, '')) * rate, [value, rate]);
 
   const currency = useMemo(
     () =>


### PR DESCRIPTION
# Description
Fix conversion to dollar above one thousand

# Summary
- [x] Just remove the comma before conversion to number

# Screenshots
![image](https://github.com/user-attachments/assets/c27e2fc6-3a5b-4545-90e2-e5b77e83195f)

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [ ] I mentioned the PR link in the task