### PR TITLE
FIX: Marketplace unnecessary mints data requests

### DIFF
--- a/apps/ui/src/hooks/marketplace/useGetMintData.ts
+++ b/apps/ui/src/hooks/marketplace/useGetMintData.ts
@@ -1,26 +1,26 @@
-import { NFTCollection } from '@/modules/marketplace/utils/mint';
 import { MarketplaceQueryKeys } from '@/utils/constants';
 import { Networks, resolveNetwork } from '@/utils/resolverNetwork';
 import { useWallet } from '@fuels/react';
 import { useQuery } from '@tanstack/react-query';
 import { bn, getAssetById, Provider } from 'fuels';
+import { useMintContract } from '../sdk/mint';
 
 const { VITE_PROVIDER_URL } = import.meta.env;
 
 export const useGetMintData = (collectionId: string, isMintable: boolean) => {
     const { wallet } = useWallet();
 
-    const { data, ...rest } = useQuery({
-        queryKey: [MarketplaceQueryKeys.MINT_TOKEN, collectionId, wallet?.provider],
-        queryFn: async () => {
-            const provider = wallet?.provider ?? new Provider(VITE_PROVIDER_URL)
-            const mintContract = new NFTCollection(collectionId, provider!);
-            const chainId = await provider.getChainId();
+    const provider = wallet?.provider ?? new Provider(VITE_PROVIDER_URL);
+    const mintContract = useMintContract(collectionId, provider, isMintable);
 
+    const { data, ...rest } = useQuery({
+        queryKey: [MarketplaceQueryKeys.MINT_TOKEN, collectionId],
+        queryFn: async () => {
+            const chainId = await provider.getChainId();
             const network = resolveNetwork(chainId ?? Networks.MAINNET);
 
             const { maxSupply, totalAssets, mintPrice } =
-                await mintContract.getResumeMint();
+                await mintContract!.getResumeMint();
 
             const asset = await getAssetById({
                 network: network?.toLowerCase() as 'mainnet' | 'testnet',
@@ -34,7 +34,8 @@ export const useGetMintData = (collectionId: string, isMintable: boolean) => {
                 asset,
             };
         },
-        enabled: !!collectionId && isMintable,
+        enabled: !!collectionId && isMintable && !!mintContract,
+        staleTime: 1000 * 60 * 5, // 5 minutes
     });
 
     return {

--- a/apps/ui/src/hooks/marketplace/useGetMintData.ts
+++ b/apps/ui/src/hooks/marketplace/useGetMintData.ts
@@ -7,7 +7,7 @@ import { bn, getAssetById, Provider } from 'fuels';
 
 const { VITE_PROVIDER_URL } = import.meta.env;
 
-export const useGetMintData = (collectionId: string) => {
+export const useGetMintData = (collectionId: string, isMintable: boolean) => {
     const { wallet } = useWallet();
 
     const { data, ...rest } = useQuery({
@@ -19,7 +19,7 @@ export const useGetMintData = (collectionId: string) => {
 
             const network = resolveNetwork(chainId ?? Networks.MAINNET);
 
-            const { maxSupply, totalAssets, mintPrice, config } =
+            const { maxSupply, totalAssets, mintPrice } =
                 await mintContract.getResumeMint();
 
             const asset = await getAssetById({
@@ -30,18 +30,16 @@ export const useGetMintData = (collectionId: string) => {
             return {
                 maxSupply,
                 minted: totalAssets,
-                config,
                 amount: mintPrice.amount,
                 asset,
             };
         },
-        enabled: !!collectionId,
+        enabled: !!collectionId && isMintable,
     });
 
     return {
         maxSupply: bn(data?.maxSupply).toString(),
         totalMinted: bn(data?.minted).toString(),
-        config: data?.config,
         mintPrice: data?.amount,
         asset: data?.asset,
         ...rest,

--- a/apps/ui/src/hooks/marketplace/useMintToken.ts
+++ b/apps/ui/src/hooks/marketplace/useMintToken.ts
@@ -23,7 +23,7 @@ export const useMintToken = (collectionId: string) => {
                     'You can now view your tokens in your wallet',
             });
             queryClient.invalidateQueries({
-                queryKey: [MarketplaceQueryKeys.MINT_TOKEN, collectionId, wallet?.provider],
+                queryKey: [MarketplaceQueryKeys.MINT_TOKEN, collectionId],
             });
         },
         onError: () => {

--- a/apps/ui/src/hooks/marketplace/useMintToken.ts
+++ b/apps/ui/src/hooks/marketplace/useMintToken.ts
@@ -23,7 +23,7 @@ export const useMintToken = (collectionId: string) => {
                     'You can now view your tokens in your wallet',
             });
             queryClient.invalidateQueries({
-                queryKey: [MarketplaceQueryKeys.MINT_TOKEN, collectionId],
+                queryKey: [MarketplaceQueryKeys.MINT_TOKEN, collectionId, wallet?.provider],
             });
         },
         onError: () => {

--- a/apps/ui/src/hooks/sdk/mint.ts
+++ b/apps/ui/src/hooks/sdk/mint.ts
@@ -1,0 +1,12 @@
+import { NFTCollection } from '@/modules/marketplace/utils/mint';
+import type { Provider } from 'fuels';
+import { useMemo } from 'react';
+
+export const useMintContract = (collectionId: string, provider: Provider, isMintable: boolean) => {
+    const contract = useMemo(() => {
+        if (!collectionId || !provider || !isMintable) return null;
+        return new NFTCollection(collectionId, provider!);
+    }, [collectionId, provider, isMintable]);
+
+    return contract;
+};

--- a/apps/ui/src/modules/marketplace/collections/page.tsx
+++ b/apps/ui/src/modules/marketplace/collections/page.tsx
@@ -64,11 +64,10 @@ export const CollectionPage = () => {
     maxSupply,
     totalMinted,
     mintPrice,
-    config,
     asset,
     isLoading: isLoadingMintData,
     isFetched: isFetchedMintData,
-  } = useGetMintData(collectionId);
+  } = useGetMintData(collectionId, collection?.data?.isMintable ?? false);
 
   const isMintable =
     Number(maxSupply) > 0 && Number(totalMinted) < Number(maxSupply);
@@ -182,11 +181,12 @@ export const CollectionPage = () => {
 
             <TabPanel p={0}>
               <MintPanel
+                collectionName={collection?.data?.name ?? ''}
                 collectionId={collectionId ?? ''}
                 maxSupply={maxSupply}
                 totalMinted={totalMinted}
                 mintPrice={mintPrice}
-                config={config}
+                config={collection?.data?.config}
                 asset={asset}
                 isLoading={isLoadingMintData || !isFetchedMintData}
                 wasAllSupplyMinted={wasAllSupplyMinted}

--- a/apps/ui/src/modules/marketplace/components/banner/root/collectionsContent.tsx
+++ b/apps/ui/src/modules/marketplace/components/banner/root/collectionsContent.tsx
@@ -9,7 +9,10 @@ const CollectionsContent = ({
   collection,
   handleRedirect,
 }: { collection: Collection; handleRedirect: () => void }) => {
-  const { totalMinted, maxSupply } = useGetMintData(collection.id);
+  const { totalMinted, maxSupply } = useGetMintData(
+    collection.id,
+    collection.isMintable
+  );
 
   const isMintable = totalMinted < maxSupply;
 

--- a/apps/ui/src/modules/marketplace/components/banner/root/collectionsContent.tsx
+++ b/apps/ui/src/modules/marketplace/components/banner/root/collectionsContent.tsx
@@ -5,16 +5,21 @@ import { StatBox } from './statBox';
 import type { Collection } from '@/types/marketplace';
 import { useGetMintData } from '@/hooks/marketplace/useGetMintData';
 
+type CollectionsContentProps = {
+  collection: Collection;
+  handleRedirect: () => void;
+};
+
 const CollectionsContent = ({
   collection,
   handleRedirect,
-}: { collection: Collection; handleRedirect: () => void }) => {
-  const { totalMinted, maxSupply } = useGetMintData(
+}: CollectionsContentProps) => {
+  const { maxSupply, totalMinted } = useGetMintData(
     collection.id,
-    collection.isMintable
+    collection.isMintable ?? false
   );
 
-  const isMintable = totalMinted < maxSupply;
+  const isMintable = Number(totalMinted) < Number(maxSupply);
 
   return (
     <Box

--- a/apps/ui/src/modules/marketplace/components/mintPanel/index.tsx
+++ b/apps/ui/src/modules/marketplace/components/mintPanel/index.tsx
@@ -16,6 +16,7 @@ type MintPanelProps = {
   asset: AssetInfo | null | undefined;
   isLoading: boolean;
   wasAllSupplyMinted: boolean;
+  collectionName: string;
 };
 
 const MintPanel = ({
@@ -27,6 +28,7 @@ const MintPanel = ({
   asset,
   isLoading,
   wasAllSupplyMinted,
+  collectionName,
 }: MintPanelProps) => {
   if (!collectionId) return null;
 
@@ -77,7 +79,7 @@ const MintPanel = ({
           </Stack>
         </Flex>
         <MintContent
-          title={`Minting ${config?.name}`}
+          title={`Minting ${collectionName}`}
           description={config?.description ?? ''}
           progress={Number(totalMinted)}
           maxSupply={Number(maxSupply)}

--- a/apps/ui/src/modules/marketplace/utils/mint.ts
+++ b/apps/ui/src/modules/marketplace/utils/mint.ts
@@ -133,14 +133,13 @@ export class NFTCollection {
      * @return {Promise<{maxSupply: number, totalAssets: number, mintPrice: {asset: string, amount: number}, config: CollectionConfig}>} A promise that resolves to the resume mint data.
      */
     async getResumeMint() {
-        const [config, maxSupply, totalAssets, mintPrice,] = await Promise.all([
-            this.collectionConfig(),
+        const [maxSupply, totalAssets, mintPrice,] = await Promise.all([
             this.getMaxSupply(),
             this.getTotalAssets(),
             this.mintPrice(),
         ]);
 
-        return { maxSupply, totalAssets, mintPrice, config };
+        return { maxSupply, totalAssets, mintPrice };
     }
 
     /**

--- a/apps/ui/src/types/marketplace.ts
+++ b/apps/ui/src/types/marketplace.ts
@@ -1,3 +1,4 @@
+import type { CollectionConfig } from '@/modules/marketplace/utils/mint';
 import type { FuelAsset, Metadata } from '@/services/fuel-assets';
 
 export interface Asset {
@@ -107,18 +108,20 @@ export enum OrderStatus {
   CANCELLED = 'CANCELLED',
 }
 
-export interface Collection {
-  config: {
-    avatar: string;
-    banner: string;
-    description: string;
-    social: {
-      x?: string;
-      site?: string;
-      discord?: string;
-    };
+type Config = CollectionConfig & {
+  avatar: string;
+  banner: string;
+  description: string;
+  social: {
+    x?: string;
+    site?: string;
+    discord?: string;
   };
-  isMintable: boolean
+};
+
+export interface Collection {
+  config: Config;
+  isMintable: boolean;
   createdAt: string;
   description: string | null;
   id: string;


### PR DESCRIPTION
### Theres no task to this PR

### This PR depends on: https://github.com/infinitybase/marketplace-indexer-poc/pull/4

# Description
Improve get mint data hook to avoid unnecessary requests

# Summary
- [x] Create a hook to initiate a memoized Mint Contract
- [x] Removed `wallet.provider` from useGetMintData queryKey
- [x] Added a new condition `isMintable` to enable or not the hook/request
- [x] Use the `config/about` informations from api response instead of contract

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [ ] I mentioned the PR link in the task