### PR TITLE
CHORE: Improve orders event polling logic

### DIFF
--- a/apps/ui/src/components/layout/marketplace.tsx
+++ b/apps/ui/src/components/layout/marketplace.tsx
@@ -2,12 +2,15 @@ import { TanStackRouterDevtools } from '@tanstack/router-devtools';
 import { Container } from './container';
 import { Content } from './content';
 import { MarketplaceHeader } from '@/modules/marketplace/components';
+import { useOrderEventPolling } from '@/hooks/marketplace/useOrderEventPolling';
 
 interface MarketplaceLayoutProps {
   children?: React.ReactNode;
 }
 
 const MarketplaceMainLayout = (props: MarketplaceLayoutProps) => {
+  // Initialize the polling for order events
+  useOrderEventPolling();
   return (
     <Container h="full" overflowY="auto" bg="input.900" backgroundImage="none">
       <MarketplaceHeader />
@@ -18,6 +21,5 @@ const MarketplaceMainLayout = (props: MarketplaceLayoutProps) => {
     </Container>
   );
 };
-
 export { MarketplaceMainLayout };
 export const MarketplaceLayout = MarketplaceMainLayout;

--- a/apps/ui/src/hooks/marketplace/useGetCollectionOrders.ts
+++ b/apps/ui/src/hooks/marketplace/useGetCollectionOrders.ts
@@ -27,12 +27,7 @@ export const useGetCollectionOrders = ({
   const { chainId } = useChainId();
   const {
     cancelledOrders,
-    removeCancelledOrders,
-    processingOrders,
-    removeProcessingOrder,
     updatedOrders,
-    purchasedOrders,
-    removePurchasedOrder,
     removeUpdatedOrders,
   } = useProcessingOrdersStore();
 
@@ -63,23 +58,9 @@ export const useGetCollectionOrders = ({
         sortDirection,
       });
 
-      const currentOrderIds = data.items.map((order) => order.id);
-      const purchasedOrdersToRemove = purchasedOrders.filter(
-        (purchasedOrder) => !currentOrderIds.includes(purchasedOrder.orderId)
-      );
-
-      if (data.items.length >= 1 && purchasedOrders.length > 0) {
-        for (const purchasedOrder of purchasedOrdersToRemove) {
-          removePurchasedOrder(purchasedOrder.orderId);
-        }
-      }
-
       const filteredData = filterAndUpdateOrdersWithProcessingState({
         items: data.items,
         cancelledOrders,
-        removeCancelledOrders,
-        processingOrders,
-        removeProcessingOrder,
         updatedOrders,
         removeUpdatedOrders,
       })

--- a/apps/ui/src/hooks/marketplace/useListInfiniteOrdersByAddress.ts
+++ b/apps/ui/src/hooks/marketplace/useListInfiniteOrdersByAddress.ts
@@ -5,11 +5,7 @@ import { Networks } from '@/utils/resolverNetwork';
 import type { Order } from '@/types/marketplace';
 import type { PaginationResult } from '@/utils/pagination';
 import { marketplaceService } from '@/services/marketplace';
-import { useMemo } from 'react';
-import {
-
-  useProcessingOrdersStore,
-} from '@/modules/marketplace/stores/processingOrdersStore';
+import { useProcessingOrdersStore } from '@/modules/marketplace/stores/processingOrdersStore';
 import { filterAndUpdateOrdersWithProcessingState } from '@/utils/handleOptimisticData';
 
 type useListInfiniteOrdersByAddressProps = {
@@ -31,20 +27,9 @@ export const useListInfiniteOrdersByAddress = ({
   const { chainId } = useChainId();
   const {
     cancelledOrders,
-    removeCancelledOrders,
-    processingOrders,
-    removeProcessingOrder,
-    isPollingEnabled,
     updatedOrders,
     removeUpdatedOrders,
   } = useProcessingOrdersStore();
-
-  const activatePolling = useMemo(() => {
-    const cancelledOrdersOwner = cancelledOrders.some((cancelledOrder) => cancelledOrder.owner === sellerAddress);
-    const processingOrdersOwner = processingOrders.some((processingOrder) => processingOrder.owner === sellerAddress);
-    const anyActionInProgress = processingOrdersOwner || updatedOrders.length > 0 || cancelledOrdersOwner;
-    return anyActionInProgress && isPollingEnabled;
-  }, [processingOrders, isPollingEnabled, updatedOrders, cancelledOrders, sellerAddress]);
 
   const {
     data: orders,
@@ -68,15 +53,13 @@ export const useListInfiniteOrdersByAddress = ({
         sellerAddress,
       });
 
-      const filteredData = activatePolling ? filterAndUpdateOrdersWithProcessingState({
+      const filteredData = filterAndUpdateOrdersWithProcessingState({
         items: data.items,
         cancelledOrders,
-        removeCancelledOrders,
-        processingOrders,
-        removeProcessingOrder,
         updatedOrders,
         removeUpdatedOrders,
-      }) : data.items;
+      })
+
 
       return {
         data: filteredData,
@@ -92,10 +75,6 @@ export const useListInfiniteOrdersByAddress = ({
     },
     placeholderData: (data) => data,
     enabled: !!chainId && !!sellerAddress,
-    refetchOnMount: activatePolling,
-    refetchOnWindowFocus: false,
-    refetchInterval: activatePolling ? 5000 : false,
-    refetchIntervalInBackground: activatePolling,
   });
 
   return {

--- a/apps/ui/src/hooks/marketplace/useOrderEventPolling.ts
+++ b/apps/ui/src/hooks/marketplace/useOrderEventPolling.ts
@@ -1,0 +1,178 @@
+import {
+    type InfiniteData,
+    useQuery,
+    useQueryClient,
+} from '@tanstack/react-query';
+import { marketplaceService, ORDER_EVENTS } from '@/services/marketplace';
+import { useAccount, useChainId } from '@fuels/react';
+import { Networks } from '@/utils/resolverNetwork';
+import { useProcessingOrdersStore } from '@/modules/marketplace/stores/processingOrdersStore';
+import { BakoIDQueryKeys, MarketplaceQueryKeys } from '@/utils/constants';
+import type { Order } from '@/types/marketplace';
+import type { PaginationResult } from '@/utils/pagination';
+
+export const useOrderEventPolling = () => {
+    const { chainId } = useChainId();
+    const {
+        processingOrders,
+        updatedOrders,
+        cancelledOrders,
+        purchasedOrders,
+        removeProcessingOrder,
+        removeUpdatedOrders,
+        removeCancelledOrders,
+        removePurchasedOrder,
+    } = useProcessingOrdersStore();
+    const queryClient = useQueryClient();
+    const { account } = useAccount();
+    const address = account?.toLowerCase();
+
+    /**
+     * Clears storage and invalidates queries based on the event type
+     * @param event - The order event type
+     * @param txId - The transaction ID to process
+     */
+    const clearStorageByEvent = (
+        event: keyof typeof ORDER_EVENTS,
+        txId: string
+    ): void => {
+        const eventHandlers = {
+            [ORDER_EVENTS.OrderCancelledEvent]: () => {
+                const orderToRemove = cancelledOrders.find(
+                    (order) => order.txId === txId
+                );
+                if (orderToRemove) {
+                    removeCancelledOrders(orderToRemove.orderId);
+                    queryClient.invalidateQueries({
+                        queryKey: [MarketplaceQueryKeys.USER_ORDERS, address],
+                    });
+                    queryClient.invalidateQueries({
+                        queryKey: [BakoIDQueryKeys.NFTS, chainId, address],
+                    });
+                }
+            },
+            [ORDER_EVENTS.OrderEditedEvent]: () => {
+                const orderToRemove = updatedOrders.find(
+                    (order) => order.txId === txId
+                );
+                if (orderToRemove) {
+                    removeUpdatedOrders(orderToRemove.orderId);
+                    queryClient.invalidateQueries({
+                        queryKey: [MarketplaceQueryKeys.USER_ORDERS, address],
+                    });
+                }
+            },
+            [ORDER_EVENTS.OrderCreatedEvent]: () => {
+                const orderToRemove = processingOrders.find(
+                    (order) => order.txId === txId
+                );
+                queryClient.invalidateQueries({
+                    queryKey: [MarketplaceQueryKeys.USER_ORDERS, address],
+                });
+                const getUserOrders: InfiniteData<PaginationResult<Order>> =
+                    queryClient.getQueryData([
+                        MarketplaceQueryKeys.USER_ORDERS,
+                        address,
+                    ]) as InfiniteData<PaginationResult<Order>>;
+
+
+                const order = getUserOrders?.pages
+                    ?.flatMap((page) => page.data)
+                    .find((order) => order.id === orderToRemove?.orderId);
+
+                if (orderToRemove && order) {
+                    removeProcessingOrder(orderToRemove.orderId);
+                    queryClient.invalidateQueries({
+                        queryKey: [MarketplaceQueryKeys.USER_ORDERS, address],
+                    });
+                }
+            },
+            [ORDER_EVENTS.OrderExecutedEvent]: () => {
+                const orderToRemove = purchasedOrders.find(
+                    (order) => order.txId === txId
+                );
+                if (orderToRemove) {
+                    removePurchasedOrder(orderToRemove.orderId);
+                    queryClient.invalidateQueries({
+                        queryKey: [BakoIDQueryKeys.NFTS, chainId, address],
+                    });
+                }
+            },
+        };
+
+        const handler = eventHandlers[event];
+        if (handler) {
+            handler();
+        } else {
+            console.log(`Unknown event type: ${event}`);
+        }
+    };
+
+    /**
+     * Collects all transaction IDs from different order arrays with their source events
+     * @returns Array of transaction objects with source event and transaction ID
+     */
+    const getAllTransactionIds = (): { source: ORDER_EVENTS; txId: string }[] => {
+        const orderCollections = [
+            { orders: processingOrders, event: ORDER_EVENTS.OrderCreatedEvent },
+            { orders: updatedOrders, event: ORDER_EVENTS.OrderEditedEvent },
+            { orders: cancelledOrders, event: ORDER_EVENTS.OrderCancelledEvent },
+            { orders: purchasedOrders, event: ORDER_EVENTS.OrderExecutedEvent },
+        ];
+
+        const txIds = new Set<string>();
+        const result: { source: ORDER_EVENTS; txId: string }[] = [];
+
+        for (const { orders, event } of orderCollections) {
+            for (const order of orders) {
+                if (order.txId && !txIds.has(order.txId)) {
+                    txIds.add(order.txId);
+                    result.push({ source: event, txId: order.txId });
+                }
+            }
+        }
+
+        return result;
+    };
+
+    const transactionIds = getAllTransactionIds();
+
+    const { isLoading, error } = useQuery({
+        queryKey: ['transactionPolling', transactionIds],
+        queryFn: async () => {
+            if (transactionIds.length === 0) {
+                return null;
+            }
+
+            for (const { source, txId } of transactionIds) {
+                try {
+                    await marketplaceService.getReceiptStatus({
+                        txId,
+                        chainId: chainId ?? Networks.MAINNET,
+                    });
+
+                    clearStorageByEvent(source, txId);
+                } catch (error) {
+                    console.error(`Error fetching status for txId ${txId}:`, error);
+                }
+            }
+
+            return null;
+        },
+        enabled: transactionIds.length > 0,
+        refetchInterval: () => {
+            const currentTransactionIds = getAllTransactionIds();
+            return currentTransactionIds.length > 0 ? 2000 : false;
+        },
+        refetchIntervalInBackground: true,
+        staleTime: 0, // Always consider data stale to ensure fresh polling
+        gcTime: 0, // Don't cache this data
+    });
+
+    return {
+        isLoading,
+        error,
+        transactionIds,
+        hasActiveTransactions: transactionIds.length > 0,
+    };
+};

--- a/apps/ui/src/modules/marketplace/stores/processingOrdersStore.ts
+++ b/apps/ui/src/modules/marketplace/stores/processingOrdersStore.ts
@@ -31,14 +31,12 @@ interface ProcessingOrdersState {
     cancelledOrders: CancelledOrder[];
     purchasedOrders: { orderId: string, txId: string }[];
     updatedOrders: ProcessingUpdatedOrder[];
-    isPollingEnabled: boolean;
 
     // Actions
     addProcessingOrders: (order: ProcessingOrder) => void;
     removeProcessingOrder: (orderId: string) => void;
     addCancelledOrders: (order: CancelledOrder) => void;
     removeCancelledOrders: (orderId: string) => void;
-    setIsPollingEnabled: (isPolling: boolean) => void;
     clearCancelledOrders: () => void;
     addPurchasedOrder: (orderId: string, txId: string) => void;
     removePurchasedOrder: (orderId: string) => void;
@@ -53,7 +51,6 @@ export const useProcessingOrdersStore = create<ProcessingOrdersState>()(
             cancelledOrders: [],
             purchasedOrders: [],
             updatedOrders: [],
-            isPollingEnabled: true,
 
             addPurchasedOrder: (orderId: string, txId: string) => {
                 set((state) => ({
@@ -120,10 +117,6 @@ export const useProcessingOrdersStore = create<ProcessingOrdersState>()(
                         (order) => order.orderId !== orderId
                     ),
                 }));
-            },
-
-            setIsPollingEnabled: (isPolling: boolean) => {
-                set({ isPollingEnabled: isPolling });
             },
 
             clearCancelledOrders: () => {

--- a/apps/ui/src/modules/profile/components/nft/NftCollectionCard.tsx
+++ b/apps/ui/src/modules/profile/components/nft/NftCollectionCard.tsx
@@ -14,7 +14,6 @@ import { BAKO_CONTRACTS_IDS } from '@/utils/constants';
 import { formatAddress } from '@/utils/formatter';
 import { NftCardModal } from './NftCardModal';
 import { NftCard } from './card';
-import { useProcessingOrdersStore } from '@/modules/marketplace/stores/processingOrdersStore';
 
 interface NftCollectionCardProps {
   asset: NFTWithImage;
@@ -37,15 +36,11 @@ export const NftCollectionCard = (props: NftCollectionCardProps) => {
   } = props.asset;
   const dialog = useDisclosure();
 
-  const { setIsPollingEnabled } = useProcessingOrdersStore();
-
   const handleOpenDialog = () => {
-    setIsPollingEnabled(false);
     dialog.onOpen();
   };
 
   const handleCloseDialog = () => {
-    setIsPollingEnabled(true);
     dialog.onClose();
   };
 

--- a/apps/ui/src/modules/profile/components/nft/NftSaleCard.tsx
+++ b/apps/ui/src/modules/profile/components/nft/NftSaleCard.tsx
@@ -44,15 +44,13 @@ const NftSaleCard = ({
   const { successToast, errorToast } = useCustomToast();
   const { cancelOrderAsync, isPending: isCanceling } = useCancelOrder();
   const { isOpen, onClose, onOpen } = useDisclosure();
-  const { setIsPollingEnabled, updatedOrders } = useProcessingOrdersStore();
+  const { updatedOrders } = useProcessingOrdersStore();
 
   const handleOpenDialog = () => {
-    setIsPollingEnabled(false);
     onOpen();
   };
 
   const handleCloseDialog = () => {
-    setIsPollingEnabled(true);
     onClose();
   };
   const delistModal = useDisclosure();

--- a/apps/ui/src/services/marketplace.ts
+++ b/apps/ui/src/services/marketplace.ts
@@ -13,6 +13,13 @@ const BASE_API_URL = import.meta.env.VITE_API_URL;
 
 const BASE_MARKETPLACE_URL = import.meta.env.VITE_MARKETPLACE_URL;
 
+export enum ORDER_EVENTS {
+  OrderCreatedEvent = 'OrderCreatedEvent',
+  OrderExecutedEvent = 'OrderExecutedEvent',
+  OrderCancelledEvent = 'OrderCancelledEvent',
+  OrderEditedEvent = 'OrderEditedEvent',
+}
+
 export class marketplaceService {
   static async getAssets({
     chainId = Networks.MAINNET,
@@ -199,9 +206,13 @@ export class marketplaceService {
     const network = resolveNetwork(chainId);
 
     try {
-      return fetch(`${BASE_MARKETPLACE_URL}/${network}/receipts/tx/${txId}`, {
+      const url = constructUrl(`${BASE_MARKETPLACE_URL}/${network}/receipts/tx/${txId}`, {});
+
+      const response = await fetch(url, {
         method: 'POST',
       });
+
+      return response.json();
     } catch {
       return null
     }
@@ -211,10 +222,24 @@ export class marketplaceService {
   static async getReceiptStatus(data: {
     txId: string;
     chainId: number;
-  }) {
+  }): Promise<{
+    success: boolean;
+    data: {
+      isProcessed: boolean;
+      event: keyof typeof ORDER_EVENTS;
+    };
+  } | null> {
     const { txId, chainId } = data;
     const network = resolveNetwork(chainId);
 
-    return fetch(`${BASE_MARKETPLACE_URL}/${network}/receipts/tx/${txId}`);
+    try {
+      const url = constructUrl(`${BASE_MARKETPLACE_URL}/${network}/receipts/tx/${txId}`, {});
+
+      const response = await fetch(url);
+
+      return response.json();
+    } catch {
+      return null
+    }
   }
 }

--- a/apps/ui/src/utils/handleOptimisticData.ts
+++ b/apps/ui/src/utils/handleOptimisticData.ts
@@ -1,64 +1,24 @@
-import type { Order } from "@/types/marketplace";
-import type { ProcessingOrder, ProcessingUpdatedOrder } from "@/modules/marketplace/stores/processingOrdersStore";
+import type { Order } from '@/types/marketplace';
+import type { ProcessingUpdatedOrder } from '@/modules/marketplace/stores/processingOrdersStore';
 
 export const filterAndUpdateOrdersWithProcessingState = ({
     items,
     cancelledOrders,
-    removeCancelledOrders,
-    processingOrders,
-    removeProcessingOrder,
     updatedOrders,
     removeUpdatedOrders,
 }: {
     items: Order[];
-    cancelledOrders: { orderId: string, owner: string }[];
-    removeCancelledOrders: (orderId: string) => void;
-    processingOrders: ProcessingOrder[];
-    removeProcessingOrder: (orderId: string) => void;
+    cancelledOrders: { orderId: string; owner: string }[];
     updatedOrders: ProcessingUpdatedOrder[];
     removeUpdatedOrders: (orderId: string) => void;
 }) => {
-    const currentOrderIds = items.map((order) => order.id);
-    const cancelledOrdersToRemove = cancelledOrders.filter(
-        (cancelledOrder) => !currentOrderIds.includes(cancelledOrder.orderId)
-    );
-
-    // Remove cancelled orders from the store if it's not in the current orders
-    // Which means that our processor already removed it
-    if (items.length >= 1 && cancelledOrders.length > 0) {
-        for (const order of cancelledOrdersToRemove) {
-            removeCancelledOrders(order.orderId);
-        }
-    }
-
     // Remove cancelled orders from the items, to not be displayed in the user profile list
     let filteredData = items.filter(
-        (order) => !cancelledOrders.some(
-            (cancelledOrder) => cancelledOrder.orderId === order.id
-        )
+        (order) =>
+            !cancelledOrders.some(
+                (cancelledOrder) => cancelledOrder.orderId === order.id
+            )
     );
-
-    // Remove processing orders from the store if it's in the list
-    // Which means that our processor already added it
-    if (filteredData.length > 0 && processingOrders.length > 0) {
-        for (const processingOrder of processingOrders) {
-            const isOrderInFilteredData = filteredData.some(
-                (item) => item.id === processingOrder.orderId
-            );
-
-            // If it's in the cancelled orders and it's NOT in the filtered data
-            // We should clear the cancelledOrdersId because our processor already cancelled it
-            const isOrderInCancelledOrders = cancelledOrders.some(
-                (cancelledOrder) => cancelledOrder.orderId === processingOrder.orderId
-            );
-            if (isOrderInCancelledOrders && !isOrderInFilteredData) {
-                removeCancelledOrders(processingOrder.orderId);
-            }
-            if (isOrderInFilteredData) {
-                removeProcessingOrder(processingOrder.orderId);
-            }
-        }
-    }
 
     if (filteredData.length > 0 && updatedOrders.length > 0) {
         const updatedFilteredData = filteredData.map((order) => {


### PR DESCRIPTION
# Description
Use a new endpoint to get when an event is completed based on it's `txId`.

# Summary
- [x] Created two new methods in the `marketplace service`: `saveReceipts` and `getReceiptStatus`
- [x] Created a new hook called `useOrderEventPolling` to poll the `getReceiptStatus` and when it's a success, refetch the necessary query to get fresh data
- [x] Since we have this new hook to handle the storage i could improve the `filterAndUpdateOrdersWithProcessingState` to make it cleaner and less verbose
- [x] No more polling from the `useListInfiniteOrdersByAddress`. All the logic is concentrated in the `useOrderEventPolling`

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [ ] I mentioned the PR link in the task