### PR TITLE
FIX: Profile NFT's - Not listed items

### DIFF
--- a/apps/ui/src/hooks/useCollections.ts
+++ b/apps/ui/src/hooks/useCollections.ts
@@ -22,6 +22,7 @@ type UseCollectionsProps = {
   address: string;
   page: number;
   pageSize?: number;
+  isInfiniteScroll?: boolean;
 };
 
 type NFTMetadata = Record<string, string>;
@@ -33,6 +34,7 @@ export const useCollections = ({
   address,
   page,
   pageSize = PAGE_SIZE,
+  isInfiniteScroll = false,
 }: UseCollectionsProps) => {
   const { chainId } = useChainId();
 
@@ -53,9 +55,21 @@ export const useCollections = ({
 
   const totalPages = allNfts ? Math.ceil(allNfts.length / pageSize) : 0;
 
-  const currentPageNfts = allNfts
-    ? chunk(allNfts, pageSize)[page - 1] || []
-    : [];
+
+  const getCurrentPageNfts = () => {
+    if (!allNfts) return [];
+
+    if (isInfiniteScroll) {
+      // For infinite scroll, include all NFTs from page 1 to current page similar to useInfiniteQuery
+      const endIndex = page * pageSize;
+      return allNfts.slice(0, endIndex);
+    }
+
+    // For regular pagination, only include NFTs from current page (Manual pagination)
+    return chunk(allNfts, pageSize)[page - 1] || [];
+  };
+
+  const currentPageNfts = getCurrentPageNfts();
 
   const {
     data: nftsWithMetadata,

--- a/apps/ui/src/modules/marketplace/profile/page.tsx
+++ b/apps/ui/src/modules/marketplace/profile/page.tsx
@@ -49,6 +49,7 @@ export const ProfilePage = () => {
   } = useCollections({
     address: owner,
     page: fuelCollectionsPage,
+    isInfiniteScroll: true,
   });
 
   const notListedCollectionsWithoutHandles = notListedCollections.filter(


### PR DESCRIPTION
# Description
Added a new logic to useCollection hook. The old logic only work with manual pagination. It "removes" the items from the previous page and return ONLY the items from the next page. 
Now if we pass the `isInfiniteScroll` props, it merge items from previous page into the next one.

# Summary
- [x] Added a new logic to useCollection hook to handle infinite scroll, similar to `useInfiniteQuery` from react-hook 


# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [ ] I mentioned the PR link in the task