### PR TITLE
FIX: Improve validation to enable profile nft requests

### DIFF
--- a/apps/ui/src/hooks/marketplace/useListInfiniteOrdersByAddress.ts
+++ b/apps/ui/src/hooks/marketplace/useListInfiniteOrdersByAddress.ts
@@ -74,7 +74,7 @@ export const useListInfiniteOrdersByAddress = ({
       };
     },
     placeholderData: (data) => data,
-    enabled: !!chainId && !!sellerAddress,
+    enabled: chainId !== undefined && chainId !== null && !!sellerAddress,
   });
 
   return {


### PR DESCRIPTION
# Description
The request wasn't being initiated in testnet because of javascript truthiness validation. 
`enabled: !!chainId` - testnet chainId is 0, so it was always "falsy".

# Summary
- [x] Change the validation `!!chainId` to `chainId !== undefined && chainId !== null` in the `useListInfiniteOrdersByAddress` hook


# Screenshots
<img width="1990" height="918" alt="image" src="https://github.com/user-attachments/assets/a7adf081-61cc-4e2b-a082-107e664f9fc3" />


# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task