### PR TITLE
FIX: Only display mint tab in mintable collections

### DIFF
--- a/apps/ui/src/modules/marketplace/collections/page.tsx
+++ b/apps/ui/src/modules/marketplace/collections/page.tsx
@@ -72,8 +72,10 @@ export const CollectionPage = () => {
   } = useGetMintData(collectionId, collection?.data?.isMintable ?? false);
 
   const wasAllSupplyMinted = Number(maxSupply) === Number(totalMinted);
+  const isMintable =
+    Number(maxSupply) > 0 && Number(totalMinted) < Number(maxSupply);
 
-  const showMintTab = !isLoadingMintData;
+  const showMintTab = !isLoadingMintData && isMintable;
 
   const handleChangeSearch = useCallback(
     (search: string) => {


### PR DESCRIPTION
# Description
Just reverted a previous validation/const `isMintable`

# Summary


# Screenshots
<img width="2115" height="916" alt="image" src="https://github.com/user-attachments/assets/1aeda25a-b534-47cd-8105-9fb0d3f2b5e4" />
# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [ ] I mentioned the PR link in the task