### PR TITLE
CHORE: Not enough coins feedback to mint and thousand separator

### DIFF
--- a/apps/ui/src/modules/marketplace/components/mintPanel/mintContent.tsx
+++ b/apps/ui/src/modules/marketplace/components/mintPanel/mintContent.tsx
@@ -11,8 +11,10 @@ import {
   Progress,
   Stack,
   Text,
+  Tooltip,
 } from '@chakra-ui/react';
-import type { AssetInfo, BN } from 'fuels';
+import { useAccount, useBalance } from '@fuels/react';
+import { bn, type AssetInfo, type BN } from 'fuels';
 import { useEffect, useMemo, useState } from 'react';
 
 type MintContentProps = {
@@ -45,20 +47,39 @@ const MintContent = ({
     if (maxSupply) return maxSupply - progress;
   }, [progress, maxSupply]);
 
+  const { account } = useAccount();
+  const {
+    balance: walletAssetBalance,
+    isLoading: isLoadingWalletBalance,
+    isFetching: isFetchingBalance,
+  } = useBalance({
+    address: account,
+    assetId: asset?.assetId,
+  });
+
   const progressPercentage = useMemo(
     () => (progress / maxSupply) * 100,
     [progress, maxSupply]
   );
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const mintPrice = useMemo(
-    () => formatAmount({
-      amount: tokenPrice,
-      options: {
-        units: asset?.decimals || 0,
-        precision: Math.min(asset?.decimals || 0, 3),
-      }
-    }),
+    () =>
+      formatAmount({
+        amount: tokenPrice,
+        options: {
+          units: asset?.decimals || 0,
+          precision: Math.min(asset?.decimals || 0, 3),
+        },
+      }),
     [tokenPrice, quantity, asset?.decimals]
   );
+
+  const notEnoughBalance = useMemo(() => {
+    if (isLoadingWalletBalance || !walletAssetBalance) return true;
+
+    return walletAssetBalance.lt(bn(tokenPrice.mul(quantity).toString()));
+  }, [walletAssetBalance, isLoadingWalletBalance, tokenPrice, quantity]);
+
   const usdPrice = useMemo(
     () =>
       convertToUsd(
@@ -177,22 +198,29 @@ const MintContent = ({
             </Flex>
           )}
         </Stack>
-        <Button
-          mt={wasAllSupplyMinted ? 4 : 0}
-          variant="mktPrimary"
-          size="lg"
-          w="full"
-          fontWeight="bold"
-          borderRadius="md"
-          letterSpacing=".5px"
-          onClick={handleMint}
-          isLoading={isMinting}
-          isDisabled={isMinting || wasAllSupplyMinted}
-        >
-          {wasAllSupplyMinted
-            ? 'Minted'
-            : `Mint ${quantity} NFT${quantity > 1 ? 's' : ''}`}
-        </Button>
+        <Tooltip label={notEnoughBalance ? 'Not enough balance' : ''}>
+          <Button
+            mt={wasAllSupplyMinted ? 4 : 0}
+            variant="mktPrimary"
+            size="lg"
+            w="full"
+            fontWeight="bold"
+            borderRadius="md"
+            letterSpacing=".5px"
+            onClick={handleMint}
+            isLoading={isMinting}
+            isDisabled={
+              isMinting ||
+              wasAllSupplyMinted ||
+              notEnoughBalance ||
+              isFetchingBalance
+            }
+          >
+            {wasAllSupplyMinted
+              ? 'Minted'
+              : `Mint ${quantity} NFT${quantity > 1 ? 's' : ''}`}
+          </Button>
+        </Tooltip>
       </Stack>
     </Flex>
   );

--- a/apps/ui/src/modules/profile/components/nft/NftSaleCard.tsx
+++ b/apps/ui/src/modules/profile/components/nft/NftSaleCard.tsx
@@ -144,6 +144,9 @@ const NftSaleCard = ({
       }).format(Number(order.price.usd)),
     [order.price.usd]
   );
+  const orderPrice = useMemo(() => {
+    return Intl.NumberFormat('en-US').format(Number(order.price.amount));
+  }, [order.price.amount]);
 
   const assetSymbolUrl = order.price.image || UnknownAsset;
 
@@ -223,7 +226,7 @@ const NftSaleCard = ({
               <Tooltip label={order.asset?.name}>
                 <Image src={assetSymbolUrl} alt="Asset Icon" w={4} height={4} />
               </Tooltip>
-              {order.price.amount}
+              {orderPrice}
             </Heading>
             {order.price.usd && !displayBuyButton && (
               <Text color="grey.subtitle" fontSize="xs" lineHeight=".9">

--- a/apps/ui/src/modules/profile/components/nft/NftSaleCardModal/NftDetailsStep.tsx
+++ b/apps/ui/src/modules/profile/components/nft/NftSaleCardModal/NftDetailsStep.tsx
@@ -111,6 +111,10 @@ export default function NftDetailsStep({
     ? `@${sellerDomain}`
     : formatAddress(order.seller);
 
+  const orderPrice = useMemo(() => {
+    return Intl.NumberFormat('en-US').format(Number(value));
+  }, [value]);
+
   return (
     <Stack
       gap={8}
@@ -153,7 +157,7 @@ export default function NftDetailsStep({
             <Image src={assetSymbolUrl} alt="Asset icon" height={6} width={6} />
           </Tooltip>
           <Text fontSize="sm" color="grey.title" fontWeight="semibold">
-            {value}
+            {orderPrice}
           </Text>
           <Text fontSize="sm" color="grey.subtitle">
             ~ {usdValue}


### PR DESCRIPTION
THIS PR DEPENDS ON: https://github.com/infinitybase/marketplace-indexer-poc/pull/10

# Description
Added a feedback when user have no coins to mint and a thousand separator

# Summary
- [x] Added same logic from nft sale modal to show a tooltip when user have no balance for mint
- [x] Added a thousand separator `,` to listed orders 


# Screenshots
<img width="1579" height="918" alt="image" src="https://github.com/user-attachments/assets/a272e537-ef34-4692-ba87-1960054642db" />
<img width="1573" height="914" alt="image" src="https://github.com/user-attachments/assets/d8e4ecb9-e32d-46ed-87bf-285f06ef1ead" />
<img width="1270" height="424" alt="image" src="https://github.com/user-attachments/assets/b598691b-267d-42a5-ba54-a1328d9771d7" />
<img width="301" height="397" alt="image" src="https://github.com/user-attachments/assets/cd59ae6e-79c4-457a-9243-77f7acd654c8" />
<img width="1895" height="907" alt="image" src="https://github.com/user-attachments/assets/8498e17e-6119-41ff-9fd1-a9bce3acc743" />




# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [ ] I mentioned the PR link in the task