### PR TITLE
FIX: Fuel Assets Api Request

### DIFF
--- a/apps/ui/src/services/fuel-assets.ts
+++ b/apps/ui/src/services/fuel-assets.ts
@@ -50,13 +50,16 @@ const networks: Record<number, string> = {
   0: 'https://explorer-indexer-testnet.fuel.network',
 };
 
+
+const FUEL_ASSETS_QUANTITY = 400;
+
 export class FuelAssetService {
   static async byAddress({
     address,
     chainId,
   }: ByAddress): Promise<ByAddressResponse> {
     const networkUrl = FuelAssetService.networkUrl(chainId);
-    const response = await fetch(`${networkUrl}/accounts/${address}/assets`);
+    const response = await fetch(`${networkUrl}/accounts/${address}/assets?last=${FUEL_ASSETS_QUANTITY}`);
     return response.json();
   }
 


### PR DESCRIPTION
# Description
Add a quantity to the `last` param in the url request from fuels assets to get more items

# Summary
- [x] Added a `400` to the `last` param in the Assets API request (`https://mainnet-explorer.fuel.network/accounts/${address}/assets`) to get more assets instead of only the first page. 


# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [ ] I mentioned the PR link in the task