### PR TITLE
Garage: Collection Page - Improve page loading and UX

### DIFF
--- a/apps/ui/src/modules/marketplace/collections/page.tsx
+++ b/apps/ui/src/modules/marketplace/collections/page.tsx
@@ -13,6 +13,7 @@ import {
 } from '@chakra-ui/react';
 import {
   Outlet,
+  useLocation,
   useNavigate,
   useParams,
   useSearch,
@@ -48,6 +49,8 @@ export const CollectionPage = () => {
     strict: false,
   });
   const navigate = useNavigate();
+  const location = useLocation();
+  const isOrderRoute = location.pathname.includes('/order/');
   const { search } = useSearch({ strict: false });
   const debouncedSearch = useDebounce<string>(search?.trim() ?? '', 700);
   const successMintDialog = useDisclosure();
@@ -146,7 +149,8 @@ export const CollectionPage = () => {
     isFetched &&
     !isLoadingMintData &&
     collection?.data?.isMintable &&
-    isCollectionStillMintable;
+    isCollectionStillMintable &&
+    !isOrderRoute;
 
   const renderSkeletonTab =
     collection?.data?.isMintable &&

--- a/apps/ui/src/modules/marketplace/collections/page.tsx
+++ b/apps/ui/src/modules/marketplace/collections/page.tsx
@@ -149,7 +149,9 @@ export const CollectionPage = () => {
     isCollectionStillMintable;
 
   const renderSkeletonTab =
-    collection?.data?.isMintable && (!isFetched || isLoadingMintData);
+    collection?.data?.isMintable &&
+    (!isFetched || isLoadingMintData) &&
+    !isInitialPageLoadCompleted.current;
 
   // Reset scroll to top when component mounts
   useEffect(() => {

--- a/apps/ui/src/modules/marketplace/components/orderList.tsx
+++ b/apps/ui/src/modules/marketplace/components/orderList.tsx
@@ -70,7 +70,6 @@ export const OrderList = ({
             isOwner={isOwner}
             showAnimatedButton
             withHandle={!!data}
-            openModalOnClick={false}
             imageSize="full"
             ctaButtonVariant="mktPrimary"
           />

--- a/apps/ui/src/modules/marketplace/components/searchBar.tsx
+++ b/apps/ui/src/modules/marketplace/components/searchBar.tsx
@@ -6,30 +6,69 @@ import {
   InputGroup,
   InputRightElement,
 } from '@chakra-ui/react';
-import { memo } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 interface SearchBarProps {
   onChange: (value: string) => void;
   placeholder?: string;
   value: string;
+  debounceMs?: number;
 }
 
 const SearchBar = ({
   onChange,
   placeholder = 'Search for asset id, seller address or handle',
   value,
+  debounceMs = 300,
 }: SearchBarProps) => {
+  const [inputValue, setInputValue] = useState(value);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
+  const debouncedOnChange = useCallback(
+    (newValue: string) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = setTimeout(() => {
+        onChange(newValue);
+      }, debounceMs);
+    },
+    [onChange, debounceMs]
+  );
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      setInputValue(newValue); // Immediate visual feedback to the input
+      debouncedOnChange(newValue); // Debounced callback to the url
+    },
+    [debouncedOnChange]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
   return (
     <FormControl pr={{ base: 3, sm: 0 }}>
       <InputGroup position="relative">
         <Input
-          onChange={(e) => onChange(e.target.value)}
+          onChange={handleInputChange}
           placeholder=" "
           type="text"
           size="lg"
           variant="outlined"
           bg="input.600"
-          value={value}
+          value={inputValue}
           border="grey.600"
         />
 

--- a/apps/ui/src/modules/profile/components/nft/NftSaleCard.tsx
+++ b/apps/ui/src/modules/profile/components/nft/NftSaleCard.tsx
@@ -19,7 +19,7 @@ import { type MouseEvent, useCallback, useMemo, useState } from 'react';
 import { NftSaleCardModal } from './NftSaleCardModal';
 import { NftCard } from './card';
 import { useProcessingOrdersStore } from '@/modules/marketplace/stores/processingOrdersStore';
-import { Link, useParams } from '@tanstack/react-router';
+import { useParams } from '@tanstack/react-router';
 import { useAccount, useBalance, useConnectUI } from '@fuels/react';
 import { bn } from 'fuels';
 import { useScreenSize } from '@/hooks';
@@ -32,7 +32,6 @@ interface NftSaleCardProps {
   isOwner: boolean;
   showAnimatedButton: boolean;
   withHandle: boolean;
-  openModalOnClick?: boolean;
   imageSize?: BoxProps['boxSize'];
   ctaButtonVariant?: 'primary' | 'mktPrimary';
   isProfilePage?: boolean;
@@ -42,7 +41,6 @@ const NftSaleCard = ({
   order,
   isOwner,
   showAnimatedButton,
-  openModalOnClick = true,
   withHandle,
   imageSize,
   ctaButtonVariant = 'primary',
@@ -93,7 +91,7 @@ const NftSaleCard = ({
       try {
         await executeOrderAsync(order.id);
         successToast({ title: 'Order executed successfully!' });
-        } catch {
+      } catch {
         errorToast({ title: 'Failed to execute order' });
       }
     },
@@ -101,7 +99,7 @@ const NftSaleCard = ({
       connect,
       executeOrderAsync,
       order.id,
-        successToast,
+      successToast,
       errorToast,
       isConnected,
     ]
@@ -170,12 +168,6 @@ const NftSaleCard = ({
   const imageUrl = parseURI(order.asset?.image) || nftEmpty;
   const name = order.asset.name || 'Unknown NFT';
 
-  const handleCardClick = () => {
-    if (openModalOnClick) {
-      handleOpenDialog();
-    }
-  };
-
   const isProcessigNewPrices = useMemo(() => {
     const hasOrderUpdated = updatedOrders.find(
       (updatedOrder) => updatedOrder.orderId === order.id
@@ -189,7 +181,7 @@ const NftSaleCard = ({
 
   return (
     <NftCard.Root
-      onClick={handleCardClick}
+      onClick={handleOpenDialog}
       cursor="pointer"
       minH="240px"
       onMouseEnter={() =>
@@ -198,15 +190,7 @@ const NftSaleCard = ({
       onMouseLeave={() => setDisplayBuyButton(false)}
       position="relative"
     >
-      <Flex
-        as={Link}
-        to={
-          isProfilePage
-            ? undefined
-            : `/collection/${slugifiedCollectionName}/order/${order.id}`
-        }
-        flexDir="column"
-      >
+      <Flex flexDir="column">
         <NftCard.Image boxSize={imageSize} src={imageUrl} />
         <NftCard.Content h={showAnimatedButton ? 'full' : '70px'}>
           <Text


### PR DESCRIPTION
# Description
Improve UX on collection page and avoid unnecessary tabs trigger when interact with searchbar or filter

# Summary
- [x] Improve searchbar debounce logic to give smooth typing in the input and avoid add every single keystroke in the browser searchbar
- [x] Add a `useRef` to track when the pages loads for the first time to prevent the "Mint" tab to be trigger wrongly, since we only need to set it as default in the first page load.
- [x] Add a new variable to the `renderSkeleton` validation to avoid components "blinking" when user interact (searchbar or select filter)
- [x] No longer redirect the users to the `sale link` when their click on the order card. (The `Copy Sale Link` button still working)
- [x] When user access a sale link and that collection have Mint we now show the `Items` tab as default. 


# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task