### PR TITLE
Garage: estimate fee before allow user execute any action

### DIFF
--- a/apps/ui/src/hooks/marketplace/index.ts
+++ b/apps/ui/src/hooks/marketplace/index.ts
@@ -6,3 +6,4 @@ export * from './useMarketplace';
 export * from './useUpdateOrder';
 export * from './useGetOrder';
 export * from './useListInfiniteOrdersByAddress';
+export * from './useGetTransactionCost';

--- a/apps/ui/src/hooks/marketplace/index.ts
+++ b/apps/ui/src/hooks/marketplace/index.ts
@@ -7,3 +7,4 @@ export * from './useUpdateOrder';
 export * from './useGetOrder';
 export * from './useListInfiniteOrdersByAddress';
 export * from './useGetTransactionCost';
+export * from './useCanPayGasFee';

--- a/apps/ui/src/hooks/marketplace/useCanPayGasFee.ts
+++ b/apps/ui/src/hooks/marketplace/useCanPayGasFee.ts
@@ -4,23 +4,30 @@ import { bn } from 'fuels';
 import { ETH_ID } from '@/utils/constants';
 import { useGetTransactionCost } from './useGetTransactionCost';
 import { MarketplaceAction } from '@bako-id/marketplace';
+import type { Order as OrderFromFuel } from '@bako-id/marketplace';
 
 interface UseCanPayGasFeeParams {
     orderId: string;
-    account: string | undefined;
+    account: string | null;
     shouldEstimateFee: boolean;
+    orderData?: OrderFromFuel
+    actionToSimulate: MarketplaceAction
 }
 
 export const useCanPayGasFee = ({
+    actionToSimulate = MarketplaceAction.EXECUTE_ORDER,
     orderId,
     account,
     shouldEstimateFee,
+    orderData,
 }: UseCanPayGasFeeParams) => {
+
     const { data: transactionCost, isLoading: isEstimatingFee } =
         useGetTransactionCost(
             orderId,
-            MarketplaceAction.EXECUTE_ORDER,
-            shouldEstimateFee
+            actionToSimulate,
+            shouldEstimateFee,
+            orderData
         );
 
     const { balance: ethBalance, isLoading: isLoadingEthBalance } = useBalance({

--- a/apps/ui/src/hooks/marketplace/useCanPayGasFee.ts
+++ b/apps/ui/src/hooks/marketplace/useCanPayGasFee.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { useBalance } from '@fuels/react';
+import { bn } from 'fuels';
+import { ETH_ID } from '@/utils/constants';
+import { useGetTransactionCost } from './useGetTransactionCost';
+import { MarketplaceAction } from '@bako-id/marketplace';
+
+interface UseCanPayGasFeeParams {
+    orderId: string;
+    account: string | undefined;
+    shouldEstimateFee: boolean;
+}
+
+export const useCanPayGasFee = ({
+    orderId,
+    account,
+    shouldEstimateFee,
+}: UseCanPayGasFeeParams) => {
+    const { data: transactionCost, isLoading: isEstimatingFee } =
+        useGetTransactionCost(
+            orderId,
+            MarketplaceAction.EXECUTE_ORDER,
+            shouldEstimateFee
+        );
+
+    const { balance: ethBalance, isLoading: isLoadingEthBalance } = useBalance({
+        address: account,
+        assetId: ETH_ID,
+    });
+
+    const canUserPayTheGasFee = useMemo(() => {
+        if (isEstimatingFee || isLoadingEthBalance) return false;
+
+        if (ethBalance?.eq(bn(0)) || !ethBalance || !transactionCost?.fee.gt(bn(0)))
+            return false;
+
+        return ethBalance?.gt(transactionCost?.fee);
+    }, [ethBalance, transactionCost, isEstimatingFee, isLoadingEthBalance]);
+
+    return {
+        canUserPayTheGasFee,
+        isEstimatingFee,
+        isLoadingEthBalance,
+        ethBalance,
+        transactionCost,
+    };
+};

--- a/apps/ui/src/hooks/marketplace/useGetTransactionCost.ts
+++ b/apps/ui/src/hooks/marketplace/useGetTransactionCost.ts
@@ -5,28 +5,38 @@ import { MarketplaceQueryKeys } from '@/utils/constants';
 
 export const useGetTransactionCost = (
   orderId: string,
-  actionToSimulate: MarketplaceAction
+  actionToSimulate: MarketplaceAction,
+  enabled: boolean
 ) => {
   const marketplaceContract = useMarketplace();
 
-  const { data, isLoading, error } = useQuery({
-    queryKey: [MarketplaceQueryKeys.TRANSACTION_COST, orderId, actionToSimulate],
+
+  const { data, isFetching, error } = useQuery({
+    queryKey: [
+      MarketplaceQueryKeys.TRANSACTION_COST,
+      orderId,
+      actionToSimulate,
+    ],
     queryFn: async () => {
       const marketplace = await marketplaceContract;
 
       const { fee } = await marketplace.simulate(orderId, actionToSimulate);
 
-      console.log('fee', fee.toString());
-
       return {
         fee,
       };
     },
+    enabled,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    // Cache data for 5 minutes to avoid refetching whenever users hover the card
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
   });
 
   return {
     data,
-    isLoading,
+    isLoading: isFetching,
     error,
   };
 };

--- a/apps/ui/src/hooks/marketplace/useGetTransactionCost.ts
+++ b/apps/ui/src/hooks/marketplace/useGetTransactionCost.ts
@@ -1,0 +1,32 @@
+import { useMarketplace } from './useMarketplace';
+import { useQuery } from '@tanstack/react-query';
+import type { MarketplaceAction } from '@bako-id/marketplace';
+import { MarketplaceQueryKeys } from '@/utils/constants';
+
+export const useGetTransactionCost = (
+  orderId: string,
+  actionToSimulate: MarketplaceAction
+) => {
+  const marketplaceContract = useMarketplace();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: [MarketplaceQueryKeys.TRANSACTION_COST, orderId, actionToSimulate],
+    queryFn: async () => {
+      const marketplace = await marketplaceContract;
+
+      const { fee } = await marketplace.simulate(orderId, actionToSimulate);
+
+      console.log('fee', fee.toString());
+
+      return {
+        fee,
+      };
+    },
+  });
+
+  return {
+    data,
+    isLoading,
+    error,
+  };
+};

--- a/apps/ui/src/hooks/marketplace/useGetTransactionCost.ts
+++ b/apps/ui/src/hooks/marketplace/useGetTransactionCost.ts
@@ -2,11 +2,13 @@ import { useMarketplace } from './useMarketplace';
 import { useQuery } from '@tanstack/react-query';
 import type { MarketplaceAction } from '@bako-id/marketplace';
 import { MarketplaceQueryKeys } from '@/utils/constants';
+import type { Order as OrderFromFuel } from '@bako-id/marketplace';
 
 export const useGetTransactionCost = (
   orderId: string,
   actionToSimulate: MarketplaceAction,
-  enabled: boolean
+  enabled: boolean,
+  orderData?: OrderFromFuel
 ) => {
   const marketplaceContract = useMarketplace();
 
@@ -20,7 +22,7 @@ export const useGetTransactionCost = (
     queryFn: async () => {
       const marketplace = await marketplaceContract;
 
-      const { fee } = await marketplace.simulate(orderId, actionToSimulate);
+      const { fee } = await marketplace.simulate(orderId, actionToSimulate, orderData);
 
       return {
         fee,

--- a/apps/ui/src/modules/marketplace/components/mobile/mobileCollectionItem.tsx
+++ b/apps/ui/src/modules/marketplace/components/mobile/mobileCollectionItem.tsx
@@ -5,6 +5,7 @@ import { Flex, Text, Grid, GridItem, Box } from '@chakra-ui/react';
 import { useRouter } from '@tanstack/react-router';
 import { isB256 } from 'fuels';
 import { useScrollReset } from '@/hooks/useScrollReset';
+import { slugify } from '@/utils/slugify';
 
 const MobileCollectionItem = ({ col }: { col: Collection }) => {
   const router = useRouter();
@@ -26,7 +27,7 @@ const MobileCollectionItem = ({ col }: { col: Collection }) => {
         await router.navigate({
           to: '/collection/$collectionName',
           params: {
-            collectionName: col.name,
+            collectionName: slugify(col.name),
           },
         });
         resetScroll();

--- a/apps/ui/src/modules/profile/components/nft/NftSaleCard.tsx
+++ b/apps/ui/src/modules/profile/components/nft/NftSaleCard.tsx
@@ -89,11 +89,15 @@ const NftSaleCard = ({
     return walletAssetBalance.lt(bn(order.price.raw));
   }, [walletAssetBalance, isLoadingWalletBalance, order.price.raw]);
 
+  const shouldEstimateFee = isOwner ? true : isHovering && !notEnoughBalance;
+
   const { canUserPayTheGasFee, isEstimatingFee } = useCanPayGasFee({
     orderId: order.id,
     account: account,
-    shouldEstimateFee: isHovering && !notEnoughBalance,
-    actionToSimulate: MarketplaceAction.EXECUTE_ORDER,
+    shouldEstimateFee,
+    actionToSimulate: isOwner
+      ? MarketplaceAction.CANCEL_ORDER
+      : MarketplaceAction.EXECUTE_ORDER,
   });
 
   const handleExecuteOrder = useCallback(

--- a/apps/ui/src/modules/profile/components/nft/NftSaleCard.tsx
+++ b/apps/ui/src/modules/profile/components/nft/NftSaleCard.tsx
@@ -2,7 +2,11 @@
 import nftEmpty from '@/assets/nft-empty.png';
 import UnknownAsset from '@/assets/unknown-asset.png';
 import { ConfirmationDialog, useCustomToast } from '@/components';
-import { useCancelOrder, useExecuteOrder } from '@/hooks/marketplace';
+import {
+  useCancelOrder,
+  useExecuteOrder,
+  useGetTransactionCost,
+} from '@/hooks/marketplace';
 import type { Order } from '@/types/marketplace';
 import { orderPriceFormatter, parseURI } from '@/utils/formatter';
 import {
@@ -26,6 +30,7 @@ import { useScreenSize } from '@/hooks';
 import { slugify } from '@/utils/slugify';
 import { useGetCollection } from '@/hooks/marketplace/useGetCollection';
 import { AnimatedCardButton } from './AnimatedCardButton';
+import { MarketplaceAction } from '@bako-id/marketplace';
 
 interface NftSaleCardProps {
   order: Order;
@@ -57,8 +62,11 @@ const NftSaleCard = ({
   const { collectionName } = useParams({ strict: false });
   const { connect, isConnected } = useConnectUI();
   const [displayBuyButton, setDisplayBuyButton] = useState(false);
-  const slugifiedCollectionName = slugify(collectionName);
   const [txId, setTxId] = useState<string | null>(null);
+  const slugifiedCollectionName = slugify(collectionName);
+
+  const { data: transactionCost, isLoading: isLoadingTransactionCost } =
+    useGetTransactionCost(order.id, MarketplaceAction.EXECUTE_ORDER);
 
   const { collection } = useGetCollection({
     collectionId: slugifiedCollectionName,
@@ -93,7 +101,8 @@ const NftSaleCard = ({
       try {
         await executeOrderAsync(order.id);
         successToast({ title: 'Order executed successfully!' });
-        } catch {
+      } catch (e) {
+        console.log('error executing order', e);
         errorToast({ title: 'Failed to execute order' });
       }
     },
@@ -101,7 +110,7 @@ const NftSaleCard = ({
       connect,
       executeOrderAsync,
       order.id,
-        successToast,
+      successToast,
       errorToast,
       isConnected,
     ]

--- a/apps/ui/src/modules/profile/components/nft/NftSaleCard.tsx
+++ b/apps/ui/src/modules/profile/components/nft/NftSaleCard.tsx
@@ -30,6 +30,7 @@ import { useScreenSize } from '@/hooks';
 import { slugify } from '@/utils/slugify';
 import { useGetCollection } from '@/hooks/marketplace/useGetCollection';
 import { AnimatedCardButton } from './AnimatedCardButton';
+import { MarketplaceAction } from '@bako-id/marketplace';
 
 interface NftSaleCardProps {
   order: Order;
@@ -90,8 +91,9 @@ const NftSaleCard = ({
 
   const { canUserPayTheGasFee, isEstimatingFee } = useCanPayGasFee({
     orderId: order.id,
-    account: account || undefined,
+    account: account,
     shouldEstimateFee: isHovering && !notEnoughBalance,
+    actionToSimulate: MarketplaceAction.EXECUTE_ORDER,
   });
 
   const handleExecuteOrder = useCallback(

--- a/apps/ui/src/modules/profile/components/nft/NftSaleCardModal/NftDetailsStep.tsx
+++ b/apps/ui/src/modules/profile/components/nft/NftSaleCardModal/NftDetailsStep.tsx
@@ -29,6 +29,7 @@ import { NftListMetadata } from '../NftListMetadata';
 import { NftMetadataBlock } from '../NftMetadataBlock';
 import ShareOrder from '../ShareOrder';
 import { getHomeUrl } from '@/utils/getHomeUrl';
+import { MarketplaceAction } from '@bako-id/marketplace';
 
 export default function NftDetailsStep({
   onClose,
@@ -83,8 +84,9 @@ export default function NftDetailsStep({
 
   const { canUserPayTheGasFee, isEstimatingFee } = useCanPayGasFee({
     orderId: order.id,
-    account: account || undefined,
+    account,
     shouldEstimateFee: !notEnoughBalance,
+    actionToSimulate: MarketplaceAction.EXECUTE_ORDER,
   });
 
   const handleExecuteOrder = useCallback(async () => {

--- a/apps/ui/src/modules/profile/components/nft/NftSaleCardModal/NftDetailsStep.tsx
+++ b/apps/ui/src/modules/profile/components/nft/NftSaleCardModal/NftDetailsStep.tsx
@@ -85,8 +85,10 @@ export default function NftDetailsStep({
   const { canUserPayTheGasFee, isEstimatingFee } = useCanPayGasFee({
     orderId: order.id,
     account,
-    shouldEstimateFee: !notEnoughBalance,
-    actionToSimulate: MarketplaceAction.EXECUTE_ORDER,
+    shouldEstimateFee: isOwner ? true : !notEnoughBalance,
+    actionToSimulate: isOwner
+      ? MarketplaceAction.CANCEL_ORDER
+      : MarketplaceAction.EXECUTE_ORDER,
   });
 
   const handleExecuteOrder = useCallback(async () => {
@@ -203,7 +205,7 @@ export default function NftDetailsStep({
             bg: 'tertiary',
           }}
         >
-          Delist NFT
+          Delist
         </Button>
       )}
 

--- a/apps/ui/src/modules/profile/components/nft/NftSaleCardModal/NftFormStep.tsx
+++ b/apps/ui/src/modules/profile/components/nft/NftSaleCardModal/NftFormStep.tsx
@@ -2,9 +2,17 @@ import { useCustomToast } from '@/components';
 import { useUpdateOrder } from '@/hooks/marketplace';
 import { useListAssets } from '@/hooks/marketplace/useListAssets';
 import type { Order } from '@/types/marketplace';
-import { Button, Heading, Flex, Stack, Text, Icon } from '@chakra-ui/react';
+import {
+  Button,
+  Heading,
+  Flex,
+  Stack,
+  Text,
+  Icon,
+  Tooltip,
+} from '@chakra-ui/react';
 import { bn } from 'fuels';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { NftCardSaleForm, type NftSaleCardForm } from '../NftCardSaleForm';
 import { CloseIcon } from '@/components/icons/closeIcon';
 import { useScreenSize } from '@/hooks';
@@ -32,6 +40,12 @@ export default function NftFormStep({
   const { errorToast, successToast } = useCustomToast();
   const { assets } = useListAssets();
   const { isMobile } = useScreenSize();
+  const [gasFeeData, setGasFeeData] = useState({
+    isEstimatingFee: false,
+    canUserPayTheGasFee: false,
+    currentValue: 0,
+  });
+
   const handleUpdateOrder = useCallback(
     async (data: NftSaleCardForm & { currentReceiveAmountInUsd: number }) => {
       try {
@@ -114,6 +128,8 @@ export default function NftFormStep({
           },
           sellPrice: value,
         }}
+        setGasFeeData={setGasFeeData}
+        nftAssetId={order.asset.id}
       />
 
       <Stack direction="row" justifyContent="space-between" mt="auto">
@@ -128,14 +144,25 @@ export default function NftFormStep({
         >
           Cancel
         </Button>
-        <Button
-          type="submit"
-          variant={ctaButtonVariant}
-          form="nft-sale-form"
-          isLoading={isPending}
+        <Tooltip
+          label={
+            !gasFeeData.canUserPayTheGasFee &&
+            !gasFeeData.isEstimatingFee &&
+            gasFeeData.currentValue > 0
+              ? 'Not enough balance'
+              : ''
+          }
         >
-          Save new price
-        </Button>
+          <Button
+            type="submit"
+            variant={ctaButtonVariant}
+            form="nft-sale-form"
+            isLoading={isPending || gasFeeData.isEstimatingFee}
+            disabled={!gasFeeData.canUserPayTheGasFee}
+          >
+            Save new price
+          </Button>
+        </Tooltip>
       </Stack>
     </Stack>
   );

--- a/apps/ui/src/utils/constants.ts
+++ b/apps/ui/src/utils/constants.ts
@@ -13,6 +13,7 @@ export enum MarketplaceQueryKeys {
   COLLECTION_ORDERS = 'collectionOrders',
   USER_ORDERS = 'userOrders',
   MINT_TOKEN = 'mintToken',
+  TRANSACTION_COST = 'transactionCost',
 }
 
 export enum BakoIDQueryKeys {

--- a/packages/marketplace/src/sdk/marketplace.ts
+++ b/packages/marketplace/src/sdk/marketplace.ts
@@ -1,5 +1,6 @@
 import {
   type Account,
+  bn,
   type BN,
   Provider,
   type ScriptTransactionRequest,
@@ -276,24 +277,23 @@ export class MarketplaceContract {
           })
           .getTransactionRequest();
         break;
-
-      default:
-        throw new Error(`Unknown action to simulate: ${actionToSimulate}`);
     }
 
-    try {
+    let fee = bn(0);
 
+    try {
       const { gasUsed, minFee } =
         await this.account.getTransactionCost(transactionRequest);
 
-      return {
-        fee: gasUsed.add(minFee),
-      };
-
+      fee = gasUsed.add(minFee);
     } catch {
-      return null
+      fee = bn(0);
     }
 
+
+    return {
+      fee
+    };
 
   }
 }

--- a/packages/marketplace/src/sdk/marketplace.ts
+++ b/packages/marketplace/src/sdk/marketplace.ts
@@ -283,10 +283,10 @@ export class MarketplaceContract {
     let fee = bn(0);
 
     try {
-      const { gasUsed, minFee } =
+      const { maxFee, } =
         await this.account.getTransactionCost(transactionRequest);
 
-      fee = gasUsed.add(minFee);
+      fee = maxFee;
     } catch {
       // Around 0.000445 ETH
       fee = bn(445);


### PR DESCRIPTION
# Description
Added a new method to estimate the fee cost of each transaction before users actually execute them. 


# OBS
We need a different loading animation/spinner to show while the request to estimate the fee is happening.

# Summary
- [x] Created a new `estimate` method on marketplace sdk to estimate fee of: Execute, create, cancel and update order
- [x] Create a new `estimateMint` method to estimate the fee of mint process

# Logic Explanation
- To buy order/nft: We don't calculate the fee as soon as the user enter in the collection page; This validation/request is only trigged when user have the amount to buy the nft AND hover the nft card
- To cancel an order: Theres a validation to verify if the user is the owner, and if it's true, and he hover the card, we execute the request
- To list an order: the `Amount` input must be greater than 0 and we also have a debounce to not trigger the request in every keystroke.

# Screenshots
<img width="1262" height="914" alt="image" src="https://github.com/user-attachments/assets/33132b66-4b6a-4008-827f-f1cf3c6f39b6" />

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task